### PR TITLE
Notify user via active channel on task completion

### DIFF
--- a/base/src/main/java/ai/agentrunr/tasks/TaskHandler.java
+++ b/base/src/main/java/ai/agentrunr/tasks/TaskHandler.java
@@ -1,6 +1,8 @@
 package ai.agentrunr.tasks;
 
 import ai.agentrunr.agent.Agent;
+import ai.agentrunr.channels.Channel;
+import ai.agentrunr.channels.ChannelRegistry;
 import org.jobrunr.jobs.annotations.Job;
 import org.jobrunr.jobs.context.JobRunrDashboardLogger;
 import org.slf4j.Logger;
@@ -14,10 +16,12 @@ public class TaskHandler {
 
     private final Agent agent;
     private final TaskRepository taskRepository;
+    private final ChannelRegistry channelRegistry;
 
-    public TaskHandler(Agent agent, TaskRepository taskRepository) {
+    public TaskHandler(Agent agent, TaskRepository taskRepository, ChannelRegistry channelRegistry) {
         this.agent = agent;
         this.taskRepository = taskRepository;
+        this.channelRegistry = channelRegistry;
     }
 
     @Job(name = "%0", retries = 3)
@@ -35,9 +39,21 @@ public class TaskHandler {
             TaskResult result = agent.prompt(taskId, agentInput, TaskResult.class);
             taskRepository.save(inProgress.withFeedback(result.feedback()).withStatus(result.newStatus()));
             LOGGER.info("Finished task: {} with status {}", task.getName(), result.newStatus());
+            notifyUser(task.getName(), result);
         } catch (Exception e) {
             taskRepository.save(inProgress.withStatus(Task.Status.todo));
             throw e;
+        }
+    }
+
+    private void notifyUser(String taskName, TaskResult result) {
+        try {
+            Channel channel = channelRegistry.getLatestChannel();
+            if (channel != null) {
+                channel.sendMessage("📋 Task '%s' completed:\n%s".formatted(taskName, result.feedback()));
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Failed to notify user about task '{}': {}", taskName, e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
- **TaskHandler** executed background tasks and saved results to files, but never notified the user — making the agent unable to proactively push updates (e.g., recurring inbox summaries via Telegram)
- Injects `ChannelRegistry` into `TaskHandler` and calls `sendMessage()` on the latest active channel after task completion
- Notification is wrapped in a try/catch so failures don't break task execution

## Test plan
- [ ] Schedule a recurring task (e.g., "check inbox every 2 minutes") and verify the feedback is pushed to Telegram/Web Chat
- [ ] Verify tasks still complete normally if no channel is available (null check + exception handling)
- [ ] Confirm the notification appears on whichever channel the user last messaged from

🤖 Generated with [Claude Code](https://claude.com/claude-code)