### PR TITLE
Prefill onboarding with existing config and add Settings link

### DIFF
--- a/app/src/main/java/ai/agentrunr/api/IndexController.java
+++ b/app/src/main/java/ai/agentrunr/api/IndexController.java
@@ -15,7 +15,8 @@ public class IndexController {
 
     @GetMapping({"", "/index"})
     public String index() {
-        if (environment.getProperty("agent.onboarding.completed", Boolean.class, false)) {
+        String provider = environment.getProperty("spring.ai.model.chat", "unknown");
+        if (!"unknown".equals(provider)) {
             return "redirect:/chat";
         }
         return "redirect:/onboarding/";

--- a/app/src/main/java/ai/agentrunr/onboarding/steps/S2_ProviderStep.java
+++ b/app/src/main/java/ai/agentrunr/onboarding/steps/S2_ProviderStep.java
@@ -4,6 +4,7 @@ import ai.agentrunr.SupportedProvider;
 import ai.agentrunr.configuration.ConfigurationManager;
 import ai.agentrunr.onboarding.OnboardingProvider;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -18,6 +19,12 @@ public class S2_ProviderStep implements OnboardingProvider {
     static final String SESSION_MODEL = "onboarding.model";
     static final String SESSION_API_KEY = "onboarding.apiKey";
 
+    private final Environment env;
+
+    public S2_ProviderStep(Environment env) {
+        this.env = env;
+    }
+
     @Override
     public String getStepId() {return "provider";}
 
@@ -30,7 +37,7 @@ public class S2_ProviderStep implements OnboardingProvider {
     @Override
     public void prepareModel(Map<String, Object> session, Map<String, Object> model) {
         model.put("providers", SupportedProvider.supportedAgents());
-        model.put("selectedProvider", session.getOrDefault(SESSION_PROVIDER, ""));
+        model.put("selectedProvider", session.getOrDefault(SESSION_PROVIDER, env.getProperty("spring.ai.model.chat", "")));
     }
 
     @Override

--- a/app/src/main/java/ai/agentrunr/onboarding/steps/S3_CredentialsStep.java
+++ b/app/src/main/java/ai/agentrunr/onboarding/steps/S3_CredentialsStep.java
@@ -3,6 +3,7 @@ package ai.agentrunr.onboarding.steps;
 import ai.agentrunr.SupportedProvider;
 import ai.agentrunr.onboarding.OnboardingProvider;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -10,6 +11,12 @@ import java.util.Map;
 @Component
 @Order(30)
 public class S3_CredentialsStep implements OnboardingProvider {
+
+    private final Environment env;
+
+    public S3_CredentialsStep(Environment env) {
+        this.env = env;
+    }
 
     @Override
     public String getStepId() {return "credentials";}
@@ -22,18 +29,20 @@ public class S3_CredentialsStep implements OnboardingProvider {
 
     @Override
     public void prepareModel(Map<String, Object> session, Map<String, Object> model) {
-        String providerId = (String) session.getOrDefault(S2_ProviderStep.SESSION_PROVIDER, "");
+        String providerId = (String) session.getOrDefault(S2_ProviderStep.SESSION_PROVIDER, env.getProperty("spring.ai.model.chat", ""));
         SupportedProvider provider = SupportedProvider.from(providerId).orElse(null);
         if (provider == null) return;
 
         String currentModel = (String) session.get(S2_ProviderStep.SESSION_MODEL);
+        String existingModel = env.getProperty(provider.createPropertyKey("chat.options.model"), "");
+        String existingApiKey = env.getProperty(provider.createPropertyKey("api-key"), "");
         model.put("selectedProvider", provider.id());
         model.put("providerLabel", provider.label());
         model.put("providerApiPropertyKey", provider.createPropertyKey("api-key"));
         model.put("chatModelPropertyKey", provider.createPropertyKey("chat.options.model"));
         model.put("requiresApiKey", provider.requiresApiKey());
-        model.put("apiKey", session.getOrDefault(S2_ProviderStep.SESSION_API_KEY, ""));
-        model.put("model", currentModel != null && !currentModel.isBlank() ? currentModel : provider.defaultModel());
+        model.put("apiKey", session.getOrDefault(S2_ProviderStep.SESSION_API_KEY, existingApiKey));
+        model.put("model", currentModel != null && !currentModel.isBlank() ? currentModel : (!existingModel.isBlank() ? existingModel : provider.defaultModel()));
         provider.systemWideToken().ifPresent(t -> model.put("systemWideTokenName", t.name()));
     }
 

--- a/app/src/main/java/ai/agentrunr/onboarding/steps/S4_AgentMdStep.java
+++ b/app/src/main/java/ai/agentrunr/onboarding/steps/S4_AgentMdStep.java
@@ -38,13 +38,19 @@ public class S4_AgentMdStep implements OnboardingProvider {
     public void prepareModel(Map<String, Object> session, Map<String, Object> model) {
         Object agentContent = session.get(SESSION_AGENT_CONTENT);
         if (agentContent == null) {
-            try {
-                agentContent = agentWorkspace.createRelative("AGENT-ORIGINAL.md").getContentAsString(StandardCharsets.UTF_8);
-            } catch (IOException e) {
-                agentContent = "";
-            }
+            agentContent = readFile("AGENT.md");
+            if (agentContent == null) agentContent = readFile("AGENT-ORIGINAL.md");
+            if (agentContent == null) agentContent = "";
         }
         model.put("agentContent", agentContent);
+    }
+
+    private String readFile(String name) {
+        try {
+            return agentWorkspace.createRelative(name).getContentAsString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     @Override

--- a/app/src/main/java/ai/agentrunr/onboarding/steps/S5_McpStep.java
+++ b/app/src/main/java/ai/agentrunr/onboarding/steps/S5_McpStep.java
@@ -2,6 +2,8 @@ package ai.agentrunr.onboarding.steps;
 
 import ai.agentrunr.configuration.ConfigurationManager;
 import ai.agentrunr.onboarding.OnboardingProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -19,7 +21,15 @@ import java.util.stream.Collectors;
 @Order(50)
 public class S5_McpStep implements OnboardingProvider {
 
+    private static final Logger log = LoggerFactory.getLogger(S5_McpStep.class);
+
     static final String SESSION_MCP_SERVERS = "onboarding.mcp.servers";
+
+    private final ConfigurationManager configurationManager;
+
+    public S5_McpStep(ConfigurationManager configurationManager) {
+        this.configurationManager = configurationManager;
+    }
 
     @Override
     public String getStepId() {return "mcp";}
@@ -35,7 +45,11 @@ public class S5_McpStep implements OnboardingProvider {
 
     @Override
     public void prepareModel(Map<String, Object> session, Map<String, Object> model) {
-        model.put("servers", getServers(session));
+        List<Map<String, Object>> servers = getServers(session);
+        if (servers.isEmpty() && !session.containsKey(SESSION_MCP_SERVERS)) {
+            servers = loadServersFromConfig();
+        }
+        model.put("servers", servers);
     }
 
     @Override
@@ -130,6 +144,59 @@ public class S5_McpStep implements OnboardingProvider {
             return new ArrayList<>((List<Map<String, Object>>) existing);
         }
         return new ArrayList<>();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> loadServersFromConfig() {
+        List<Map<String, Object>> servers = new ArrayList<>();
+        try {
+            Map<String, Object> yaml = configurationManager.readApplicationYaml();
+            Map<String, Object> mcp = navigateTo(yaml, "spring", "ai", "mcp", "client");
+            if (mcp == null) return servers;
+
+            Map<String, Object> httpConns = navigateTo(mcp, "streamable-http", "connections");
+            if (httpConns != null) {
+                httpConns.forEach((name, v) -> {
+                    Map<String, Object> conn = (Map<String, Object>) v;
+                    Map<String, Object> server = new LinkedHashMap<>();
+                    server.put("name", name);
+                    server.put("type", "streamable-http");
+                    String url = String.valueOf(conn.getOrDefault("url", ""));
+                    String endpoint = String.valueOf(conn.getOrDefault("endpoint", ""));
+                    server.put("url", url + endpoint);
+                    server.put("headers", conn.getOrDefault("headers", Map.of()));
+                    servers.add(server);
+                });
+            }
+
+            Map<String, Object> stdioConns = navigateTo(mcp, "stdio", "connections");
+            if (stdioConns != null) {
+                stdioConns.forEach((name, v) -> {
+                    Map<String, Object> conn = (Map<String, Object>) v;
+                    Map<String, Object> server = new LinkedHashMap<>();
+                    server.put("name", name);
+                    server.put("type", "stdio");
+                    server.put("command", conn.getOrDefault("command", ""));
+                    server.put("args", conn.getOrDefault("args", List.of()));
+                    server.put("env", conn.getOrDefault("env", Map.of()));
+                    servers.add(server);
+                });
+            }
+        } catch (IOException e) {
+            log.warn("Failed to load MCP servers from config: {}", e.getMessage());
+        }
+        return servers;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> navigateTo(Map<String, Object> map, String... keys) {
+        for (String key : keys) {
+            if (map == null) return null;
+            Object next = map.get(key);
+            if (next instanceof Map) map = (Map<String, Object>) next;
+            else return null;
+        }
+        return map;
     }
 
     /**

--- a/app/src/main/resources/templates/chat.html.peb
+++ b/app/src/main/resources/templates/chat.html.peb
@@ -155,6 +155,11 @@
         </div>
         <div class="navbar-end">
             <div class="navbar-item">
+                <a href="/onboarding" class="button is-small is-dark">
+                    <span>Settings</span>
+                </a>
+            </div>
+            <div class="navbar-item">
                 <a href="http://localhost:{{ jobrunrDashboardPort }}" target="_blank" rel="noopener noreferrer" class="button is-small is-dark">
                     <span>JobRunr Dashboard</span>
                 </a>

--- a/base/src/main/java/ai/agentrunr/configuration/ConfigurationManager.java
+++ b/base/src/main/java/ai/agentrunr/configuration/ConfigurationManager.java
@@ -42,7 +42,7 @@ public class ConfigurationManager {
         writeApplicationYaml(config);
     }
 
-    private Map<String, Object> readApplicationYaml() throws IOException {
+    public Map<String, Object> readApplicationYaml() throws IOException {
         Yaml yaml = new Yaml();
 
         Map<String, Object> config;

--- a/plugins/telegram/src/main/java/ai/agentrunr/channels/telegram/TelegramOnboardingProvider.java
+++ b/plugins/telegram/src/main/java/ai/agentrunr/channels/telegram/TelegramOnboardingProvider.java
@@ -3,6 +3,7 @@ package ai.agentrunr.channels.telegram;
 import ai.agentrunr.configuration.ConfigurationManager;
 import ai.agentrunr.onboarding.OnboardingProvider;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -14,6 +15,12 @@ public class TelegramOnboardingProvider implements OnboardingProvider {
 
     static final String SESSION_TOKEN = "onboarding.telegram.token";
     static final String SESSION_USERNAME = "onboarding.telegram.username";
+
+    private final Environment env;
+
+    public TelegramOnboardingProvider(Environment env) {
+        this.env = env;
+    }
 
     @Override
     public boolean isOptional() { return true; }
@@ -29,7 +36,8 @@ public class TelegramOnboardingProvider implements OnboardingProvider {
 
     @Override
     public void prepareModel(Map<String, Object> session, Map<String, Object> model) {
-        model.put("telegramUsername", session.getOrDefault(SESSION_USERNAME, ""));
+        model.put("telegramUsername", session.getOrDefault(SESSION_USERNAME, env.getProperty("agent.channels.telegram.username", "")));
+        model.put("telegramToken", session.getOrDefault(SESSION_TOKEN, env.getProperty("agent.channels.telegram.token", "")));
     }
 
     @Override

--- a/plugins/telegram/src/main/resources/templates/onboarding/steps/telegram.html.peb
+++ b/plugins/telegram/src/main/resources/templates/onboarding/steps/telegram.html.peb
@@ -18,7 +18,7 @@
         <div class="field">
             <label class="label" for="telegramBotToken">Telegram bot token</label>
             <div class="control">
-                <input id="telegramBotToken" class="input is-medium" type="password" name="telegramBotToken" placeholder="Paste the Telegram bot token" autocomplete="off">
+                <input id="telegramBotToken" class="input is-medium" type="password" name="telegramBotToken" value="{{ telegramToken }}" placeholder="Paste the Telegram bot token" autocomplete="off">
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- **Onboarding prefill**: Re-running onboarding now prefills all steps with existing config values (provider, model, API key, AGENT.md, MCP servers, Telegram credentials) so users don't have to re-enter everything
- **Settings link**: Added a "Settings" button in the chat navbar for quick access to re-run onboarding
- **Smart redirect**: Root URL (`/`) now infers whether onboarding was completed by checking if `spring.ai.model.chat` is set to a real provider (not `"unknown"`), instead of relying on a separate flag

> **Note:** `agent.onboarding.completed` in `S6_CompleteStep` and `application.yaml` is now redundant since the redirect infers completion from `spring.ai.model.chat`. It could be removed in a future cleanup but is intentionally left in place for now.

## Test plan
- [ ] Fresh install (default `spring.ai.model.chat: unknown`): `/` redirects to `/onboarding`
- [ ] Configured install: `/` redirects to `/chat`
- [ ] Click "Settings" in chat navbar → opens onboarding with all fields prefilled
- [ ] Walk through each step and verify existing values are shown (provider, model, API key, AGENT.md content, MCP servers, Telegram token + username)
- [ ] Complete onboarding again → config is updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)