### PR TITLE
Rename chat avatar from AR to JC and reset AGENT.md

### DIFF
--- a/app/src/main/java/ai/javaclaw/chat/ChatChannel.java
+++ b/app/src/main/java/ai/javaclaw/chat/ChatChannel.java
@@ -107,7 +107,7 @@ public class ChatChannel implements Channel {
     private static String buildBackgroundMessageHtml(String text) {
         return "<div id=\"chat-messages\" hx-swap-oob=\"beforeend show:bottom\">" +
                 "<article class=\"ar-msg ar-msg--agent\">" +
-                "<div class=\"ar-msg__avatar\">AR</div>" +
+                "<div class=\"ar-msg__avatar\">JC</div>" +
                 "<div class=\"ar-msg__bubble\">" + HtmlUtils.htmlEscape(text) + "</div>" +
                 "</article></div>";
     }

--- a/app/src/main/java/ai/javaclaw/chat/ws/ChatWebSocketHandler.java
+++ b/app/src/main/java/ai/javaclaw/chat/ws/ChatWebSocketHandler.java
@@ -72,14 +72,14 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
     static String agentBubble(String text) {
         return "<article class=\"ar-msg ar-msg--agent\">" +
-                "<div class=\"ar-msg__avatar\">AR</div>" +
+                "<div class=\"ar-msg__avatar\">JC</div>" +
                 "<div class=\"ar-msg__bubble\">" + escape(text) + "</div>" +
                 "</article>";
     }
 
     private static String typingDots() {
         return "<div class=\"ar-typing\">" +
-                "<div class=\"ar-msg__avatar\">AR</div>" +
+                "<div class=\"ar-msg__avatar\">JC</div>" +
                 "<div class=\"ar-typing__dots\"><span></span><span></span><span></span></div>" +
                 "</div>";
     }

--- a/app/src/main/resources/templates/chat.html.peb
+++ b/app/src/main/resources/templates/chat.html.peb
@@ -174,7 +174,7 @@
         <div class="container">
             <div id="chat-messages">
                 <article class="ar-msg ar-msg--agent">
-                    <div class="ar-msg__avatar">AR</div>
+                    <div class="ar-msg__avatar">JC</div>
                     <div class="ar-msg__bubble">Hi! I'm your JavaClaw assistant. How can I help you today?</div>
                 </article>
             </div>

--- a/workspace/AGENT.md
+++ b/workspace/AGENT.md
@@ -1,10 +1,6 @@
-You are an interactive assistant working for Ronald Dehuysser helping them with all their tasks and todos. Use the skills and the tools available to you to assist the user.
-Here is useful information about Ronald Dehuysser:
-    - (google) email: ronald.dehuysser@gmail.com
-    - work role: CTO at JobRunr / Java Developer
-    - address: Gallicstraat 68, 3300 Tienen
-    - married to Evelien Straetmans (born 03/01/1989)
-    - children:
-        - Lena Dehuysser (born 12/07/2013)
-        - Otis Dehuysser (born 17/03/2018)
-        - Eben Dehuysser (born 09/07/2019)
+You are an interactive assistant working for <your full name> helping them with all their tasks and todos. Use the skills and the tools available to you to assist the user.
+Here is useful information about <your full name>:
+    - email: <your email address>
+    - work role: <your work role>
+    - address: <your address>
+    - any other info you want to share like spouse (with birthdate) and children.  


### PR DESCRIPTION
## Summary
- Renamed the chat interface avatar initials from "AR" to "JC" (JavaClaw) across all three locations: `ChatWebSocketHandler`, `ChatChannel`, and `chat.html.peb`
- Reset `workspace/AGENT.md` to the standard template with placeholder values, removing personal information

## Test plan
- [ ] Verify chat interface shows "JC" avatar initials for agent messages
- [ ] Verify typing indicator shows "JC" initials
- [ ] Verify background task messages show "JC" initials
- [ ] Confirm `AGENT.md` contains only placeholder template values

🤖 Generated with [Claude Code](https://claude.com/claude-code)