### PR TITLE
Improve 'no AI model configured' error message

### DIFF
--- a/base/src/main/java/ai/javaclaw/JavaClawConfiguration.java
+++ b/base/src/main/java/ai/javaclaw/JavaClawConfiguration.java
@@ -46,7 +46,7 @@ public class JavaClawConfiguration {
     @Bean
     @ConditionalOnProperty(name = SpringAIModelProperties.CHAT_MODEL, havingValue = "unknown", matchIfMissing = true)
     public ChatModel chatModel() {
-        return prompt -> new ChatResponse(List.of(new Generation(new AssistantMessage("No AI model has been configured"))));
+        return prompt -> new ChatResponse(List.of(new Generation(new AssistantMessage("No AI model has been configured. If you did configure a model recently, restart JavaClaw manually for the changes to take effect."))));
     }
 
     @Bean


### PR DESCRIPTION
## Summary
- Adds a restart hint to the "No AI model has been configured" error message, so users who recently configured a model know they need to restart JavaClaw for changes to take effect.

## Test plan
- [ ] Start JavaClaw without configuring a model and verify the updated message appears
- [ ] Configure a model, verify the hint is helpful for users who haven't restarted

🤖 Generated with [Claude Code](https://claude.com/claude-code)