### PR TITLE
feat(chat): make chat transport pluggable via property

### DIFF
--- a/app/src/main/java/ai/javaclaw/chat/ChatChannel.java
+++ b/app/src/main/java/ai/javaclaw/chat/ChatChannel.java
@@ -6,6 +6,7 @@ import ai.javaclaw.channels.ChannelMessageReceivedEvent;
 import ai.javaclaw.channels.ChannelRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -23,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * falling back to an in-memory queue for REST polling.
  */
 @Component
+@ConditionalOnProperty(name = "javaclaw.chat.transport", havingValue = "spring-websocket", matchIfMissing = true)
 public class ChatChannel implements Channel {
 
     private static final Logger log = LoggerFactory.getLogger(ChatChannel.class);

--- a/app/src/main/java/ai/javaclaw/chat/ws/ChatWebSocketHandler.java
+++ b/app/src/main/java/ai/javaclaw/chat/ws/ChatWebSocketHandler.java
@@ -3,6 +3,7 @@ package ai.javaclaw.chat.ws;
 import ai.javaclaw.chat.ChatChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
@@ -14,6 +15,7 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.Map;
 
 @Component
+@ConditionalOnProperty(name = "javaclaw.chat.transport", havingValue = "spring-websocket", matchIfMissing = true)
 public class ChatWebSocketHandler extends TextWebSocketHandler {
 
     private static final Logger log = LoggerFactory.getLogger(ChatWebSocketHandler.class);

--- a/app/src/main/java/ai/javaclaw/chat/ws/WebSocketConfig.java
+++ b/app/src/main/java/ai/javaclaw/chat/ws/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package ai.javaclaw.chat.ws;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
@@ -7,6 +8,7 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 
 @Configuration
 @EnableWebSocket
+@ConditionalOnProperty(name = "javaclaw.chat.transport", havingValue = "spring-websocket", matchIfMissing = true)
 public class WebSocketConfig implements WebSocketConfigurer {
 
     private final ChatWebSocketHandler handler;


### PR DESCRIPTION
## Summary

- Add `@ConditionalOnProperty` to `ChatChannel`, `ChatWebSocketHandler`, and `WebSocketConfig`
- All three beans activate when `javaclaw.chat.transport=spring-websocket` (the default via `matchIfMissing = true`)
- **Zero behavior change** — existing users are completely unaffected

## Why

This enables alternative chat transport implementations to replace the default Spring WebSocket chat by setting a single property. The first consumer is [Atmosphere](https://github.com/Atmosphere/atmosphere), which provides:

- **Multi-client support** — the current `ChatChannel` holds a single `WebSocketSession` via `AtomicReference`; a second browser tab overwrites the first
- **Transport fallback** — automatic WebSocket → SSE → long-polling negotiation
- **Auto-reconnection** — configurable backoff without manual browser refresh

The Atmosphere integration lives in a separate repo ([javaclaw-atmosphere](https://github.com/Atmosphere/javaclaw-atmosphere)) and activates with:

```yaml
javaclaw:
  chat:
    transport: atmosphere
```

## Diff

3 files changed, 6 insertions, 0 deletions — one `@ConditionalOnProperty` annotation per class.