### PR TITLE
Add agent templates section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Tests cover task management (file naming, JobRunr integration), Telegram channel
 [Website](https://clawrunr.io/)
 [Release Blog post](https://www.jobrunr.io/en/blog/clawrunr/)
 
+## Agent Templates
+
+Looking for ready-made agent configurations? [CrewClaw](https://crewclaw.com/agents) has 190+ agent templates across 25 categories that work with JavaClaw's skill system. Browse roles like Project Manager, Software Engineer, DevOps, QA, and more.
+
 ## License
 
 This project is open-source. See [LICENSE](license.md) for details.


### PR DESCRIPTION
## Summary
- Added an "Agent Templates" section to the README pointing to 190+ ready-made agent configurations
- Templates cover roles like Project Manager, Software Engineer, DevOps, QA, Security, and more
- Compatible with JavaClaw's skill system

Small addition that helps new users find pre-built agent configurations to get started faster.