### PR TITLE
Use `Builder.httpRequestCustomizer` instead of removed `Builder.customizeRequest()`

### DIFF
--- a/base/src/main/java/ai/javaclaw/mcp/McpHeaderCustomizer.java
+++ b/base/src/main/java/ai/javaclaw/mcp/McpHeaderCustomizer.java
@@ -19,7 +19,8 @@ public class McpHeaderCustomizer implements McpClientCustomizer<HttpClientStream
     public void customize(String name, HttpClientStreamableHttpTransport.Builder builder) {
         McpConnectionsProperties.Connection connection = properties.connections().get(name);
         if (connection != null && !connection.headers().isEmpty()) {
-            builder.customizeRequest(r -> connection.headers().forEach(r::header));
+            builder.httpRequestCustomizer((r, method, endpoint, body, context) ->
+                connection.headers().forEach(r::header));
         }
     }
 }


### PR DESCRIPTION
The fix replaces the removed customizeRequest() method with the new httpRequestCustomizer(McpSyncHttpClientRequestCustomizer) API introduced in MCP SDK 2.0.0-M2. The lambda adapts to the new interface signature (builder, method, endpoint, body, context) while keeping the same header-forwarding logic.