### PR TITLE
Fix build config and onboarding config loading

### DIFF
--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: JavaClaw
   config:
-    import: optional:classpath:application.private.yaml.older
+    import: optional:classpath:application.private.yaml
   datasource:
     url: jdbc:h2:file:./workspace/app
   ai:

--- a/base/src/main/java/ai/javaclaw/JavaClawConfiguration.java
+++ b/base/src/main/java/ai/javaclaw/JavaClawConfiguration.java
@@ -97,8 +97,8 @@ public class JavaClawConfiguration {
         chatClientBuilder
                 .defaultAdvisors(new SimpleLoggerAdvisor())
                 .defaultSystem(p -> p.text(agentPrompt).param(AgentEnvironment.ENVIRONMENT_INFO_KEY, AgentEnvironment.info()))
-                .defaultToolCallbacks(mcpToolProvider.getToolCallbacks())
-                .defaultToolCallbacks(SkillsTool.builder()
+                .defaultTools((Object[]) mcpToolProvider.getToolCallbacks())
+                .defaultTools(SkillsTool.builder()
                         .addSkillsDirectory(skillsDir(workspace).toString())
                         .addSkillsResources(skillPaths)
                         .build()

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,12 @@ configure(subprojects.findAll { it.buildFile.exists() }) {
             testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
         }
 
+        plugins.withId('org.springframework.boot') {
+            dependencies {
+                developmentOnly(platform(libs.bom.spring.boot))
+            }
+        }
+
         java {
             toolchain {
                 languageVersion = JavaLanguageVersion.of(25)

--- a/providers/anthropic/src/main/java/ai/javaclaw/providers/anthropic/AnthropticClaudeCodeConfiguration.java
+++ b/providers/anthropic/src/main/java/ai/javaclaw/providers/anthropic/AnthropticClaudeCodeConfiguration.java
@@ -10,7 +10,6 @@ import org.springframework.ai.anthropic.http.okhttp.SpringAiAnthropicHttpClient;
 import org.springframework.ai.chat.observation.ChatModelObservationConvention;
 import org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatProperties;
 import org.springframework.ai.model.anthropic.autoconfigure.AnthropicConnectionProperties;
-import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -24,7 +23,7 @@ public class AnthropticClaudeCodeConfiguration {
 
     @Bean
     public AnthropicChatModel anthropicChatModel(AnthropicConnectionProperties connectionProperties,
-                                                 AnthropicChatProperties chatProperties, ToolCallingManager toolCallingManager,
+                                                 AnthropicChatProperties chatProperties,
                                                  ObjectProvider<ObservationRegistry> observationRegistry,
                                                  ObjectProvider<ChatModelObservationConvention> observationConvention) {
 
@@ -36,7 +35,6 @@ public class AnthropticClaudeCodeConfiguration {
                 .anthropicClient(client)
                 .anthropicClientAsync(client.async())
                 .options(options)
-                .toolCallingManager(toolCallingManager)
                 .observationRegistry(observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP))
                 .build();
 


### PR DESCRIPTION
- build.gradle: apply Spring Boot BOM to the developmentOnly configuration for Boot modules so spring-boot-devtools resolves its version from the catalog instead of failing with an empty version
- application.yaml: correct config import filename (application.private.yaml.older -> application.private.yaml) so the private config is actually loaded and onboarding.completed is honored
- AnthropticClaudeCodeConfiguration: drop deprecated AnthropicChatModel.Builder#toolCallingManager (tool calling runs via the ChatClient ToolCallingAdvisor)
- JavaClawConfiguration: migrate deprecated defaultToolCallbacks(...) to defaultTools(...)