### PR TITLE
Enforce module boundaries: Modulith verification + ArchUnit for plugin isolation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-websocket-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
+    testImplementation libs.spring.modulith.starter.test
+    testImplementation libs.archunit.junit5
 }
 
 bootRun {

--- a/app/src/test/java/ai/javaclaw/ModularityTests.java
+++ b/app/src/test/java/ai/javaclaw/ModularityTests.java
@@ -1,0 +1,14 @@
+package ai.javaclaw;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.modulith.core.ApplicationModules;
+
+class ModularityTests {
+
+    ApplicationModules modules = ApplicationModules.of(JavaClawApplication.class);
+
+    @Test
+    void verifiesModularStructure() {
+        modules.verify();
+    }
+}

--- a/app/src/test/java/ai/javaclaw/ModuleBoundaryArchTest.java
+++ b/app/src/test/java/ai/javaclaw/ModuleBoundaryArchTest.java
@@ -5,6 +5,8 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
+import java.util.stream.Stream;
+
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
@@ -12,15 +14,15 @@ import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.sli
 class ModuleBoundaryArchTest {
 
     private static final String[] CORE_PACKAGES = {
-            "..agent..", "..tasks..", "..configuration..", "..files.."
+            "ai.javaclaw.agent..", "ai.javaclaw.tasks..", "ai.javaclaw.configuration..", "ai.javaclaw.files.."
     };
 
     private static final String[] PLUGIN_PACKAGES = {
-            "..channels.telegram..", "..channels.discord..", "..tools.brave..", "..tools.playwright.."
+            "ai.javaclaw.channels.*..", "ai.javaclaw.tools.*.."
     };
 
     private static final String[] PROVIDER_PACKAGES = {
-            "..providers.openai..", "..providers.anthropic..", "..providers.ollama..", "..providers.google.."
+            "ai.javaclaw.providers.."
     };
 
     @ArchTest
@@ -48,12 +50,7 @@ class ModuleBoundaryArchTest {
     @ArchTest
     static final ArchRule coreDoesNotDependOnPluginsOrProviders =
             noClasses().that().resideInAnyPackage(CORE_PACKAGES)
-                    .should().dependOnClassesThat().resideInAnyPackage(concat(PLUGIN_PACKAGES, PROVIDER_PACKAGES));
-
-    private static String[] concat(String[] first, String[] second) {
-        String[] result = new String[first.length + second.length];
-        System.arraycopy(first, 0, result, 0, first.length);
-        System.arraycopy(second, 0, result, first.length, second.length);
-        return result;
-    }
+                    .should().dependOnClassesThat().resideInAnyPackage(
+                            Stream.concat(Stream.of(PLUGIN_PACKAGES), Stream.of(PROVIDER_PACKAGES))
+                                    .toArray(String[]::new));
 }

--- a/app/src/test/java/ai/javaclaw/ModuleBoundaryArchTest.java
+++ b/app/src/test/java/ai/javaclaw/ModuleBoundaryArchTest.java
@@ -1,0 +1,59 @@
+package ai.javaclaw;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+@AnalyzeClasses(packages = "ai.javaclaw", importOptions = ImportOption.DoNotIncludeTests.class)
+class ModuleBoundaryArchTest {
+
+    private static final String[] CORE_PACKAGES = {
+            "..agent..", "..tasks..", "..configuration..", "..files.."
+    };
+
+    private static final String[] PLUGIN_PACKAGES = {
+            "..channels.telegram..", "..channels.discord..", "..tools.brave..", "..tools.playwright.."
+    };
+
+    private static final String[] PROVIDER_PACKAGES = {
+            "..providers.openai..", "..providers.anthropic..", "..providers.ollama..", "..providers.google.."
+    };
+
+    @ArchTest
+    static final ArchRule channelPluginsAreIndependent =
+            slices().matching("..channels.(*)..").should().notDependOnEachOther();
+
+    @ArchTest
+    static final ArchRule toolPluginsAreIndependent =
+            slices().matching("..tools.(*)..").should().notDependOnEachOther();
+
+    @ArchTest
+    static final ArchRule llmProvidersAreIndependent =
+            slices().matching("..providers.(*)..").should().notDependOnEachOther();
+
+    @ArchTest
+    static final ArchRule providersDoNotDependOnPlugins =
+            noClasses().that().resideInAnyPackage(PROVIDER_PACKAGES)
+                    .should().dependOnClassesThat().resideInAnyPackage(PLUGIN_PACKAGES);
+
+    @ArchTest
+    static final ArchRule pluginsDoNotDependOnProviders =
+            noClasses().that().resideInAnyPackage(PLUGIN_PACKAGES)
+                    .should().dependOnClassesThat().resideInAnyPackage(PROVIDER_PACKAGES);
+
+    @ArchTest
+    static final ArchRule coreDoesNotDependOnPluginsOrProviders =
+            noClasses().that().resideInAnyPackage(CORE_PACKAGES)
+                    .should().dependOnClassesThat().resideInAnyPackage(concat(PLUGIN_PACKAGES, PROVIDER_PACKAGES));
+
+    private static String[] concat(String[] first, String[] second) {
+        String[] result = new String[first.length + second.length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ spring-boot = "4.0.6"
 spring-ai = "2.0.0"
 telegrambots = "9.5.0"
 commonmark = "0.28.0"
+archunit = "1.4.2"
 
 [libraries]
 bom-spring-boot = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
@@ -10,6 +11,8 @@ bom-spring-ai = { module = "org.springframework.ai:spring-ai-bom", version.ref =
 bom-spring-modulith = { module = "org.springframework.modulith:spring-modulith-bom", version = "2.0.6" }
 spring-ai-agent-utils = { module = "org.springaicommunity:spring-ai-agent-utils", version = "0.9.0" }
 spring-ai-lucene = { module = "org.apache.lucene:lucene-core", version = "9.12.3" }
+spring-modulith-starter-test = { module = "org.springframework.modulith:spring-modulith-starter-test" }
+archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version.ref = "archunit" }
 
 netty-resolver-dns-native-macos = { module = "io.netty:netty-resolver-dns-native-macos", version = "4.2.12.Final" }
 jobrunr-spring-starter = { module = "org.jobrunr:jobrunr-spring-boot-4-starter", version = "8.6.1" }


### PR DESCRIPTION
## Summary
- Adds `spring-modulith-starter-test` and `archunit-junit5` as `testImplementation` in `app/build.gradle` (ArchUnit pinned to 1.4.2, the first release supporting Java 25 class files, matching this project's toolchain).
- Adds `ModularityTests` running `ApplicationModules.of(JavaClawApplication.class).verify()` to catch cycles between top-level modules.
- Adds `ModuleBoundaryArchTest` with ArchUnit rules covering:
  - Channel plugins independent of each other (`telegram` ↮ `discord`, generalized to any `channels.*` slice)
  - Tool plugins independent of each other (`brave` ↮ `playwright`, generalized to any `tools.*` slice)
  - LLM providers independent of each other (`openai` ↮ `anthropic`, generalized to all providers)
  - Providers and plugins don't depend on each other
  - Core (`agent`, `tasks`, `configuration`, `files`) doesn't depend on any plugin or provider

Test-scope only, no production code touched.

Resolves #76